### PR TITLE
added deps to app resource file

### DIFF
--- a/src/fakerl.app.src
+++ b/src/fakerl.app.src
@@ -3,6 +3,7 @@
   {description, "Application for generating fake data"},
   {vsn, "1"},
   {registered, []},
+  {included_applications, [ jsx, qdate, yamerl, kvc, triq ]},
   {applications, [
                   kernel,
                   stdlib


### PR DESCRIPTION
Hi -- I ran into a small issue while building up a release where the fakerl deps were not declared in its app file.  (I use fakerl to generate data for automated post-release testing, which is why it's part of the release ... I can imagine wondering.)  Anyhow, here's a quick PR with the update.  Note that this change is **not** compatible if projects bundling fakerl declared fakerl's deps in their own app file (relx, at least, complains that duplication applications are included).  

Anyhow, thanks again for the library, it's been a godsend!
